### PR TITLE
Add support for Rails 6.1

### DIFF
--- a/lib/activerecord-clean-db-structure/tasks/clean_db_structure.rake
+++ b/lib/activerecord-clean-db-structure/tasks/clean_db_structure.rake
@@ -1,6 +1,6 @@
 require 'activerecord-clean-db-structure/clean_dump'
 
-Rake::Task['db:structure:dump'].enhance do
+Rake::Task['db:schema:dump'].enhance do
   filenames = []
   filenames << ENV['DB_STRUCTURE'] if ENV.key?('DB_STRUCTURE')
 


### PR DESCRIPTION
References: https://github.com/lfittl/activerecord-clean-db-structure/pull/26

**Beschrijving:**
In Rails 6.1 wordt na een migratie `db:schema:dump` getriggert in plaats van `db:structure:dump`. In deze PR zorgen we er voor dat `db:schema:dump` enhanced wordt in plaats van `db:structure:dump`, zodat de schema cleanup blijft plaats vinden.